### PR TITLE
trying to fix deque errors in angle.Robot constructor

### DIFF
--- a/revolve/angle/manage/robot.py
+++ b/revolve/angle/manage/robot.py
@@ -38,7 +38,6 @@ class Robot(object):
         self.last_mate = None
 
         self.parents = set() if parents is None else parents
-
         self._ds = deque(maxlen=speed_window)
         self._dt = deque(maxlen=speed_window)
         self._positions = deque(maxlen=speed_window)

--- a/revolve/angle/manage/world.py
+++ b/revolve/angle/manage/world.py
@@ -439,7 +439,7 @@ class WorldManager(manage.WorldManager):
         :return:
         :rtype: Robot
         """
-        return Robot(robot_name, tree, robot, position, time, parents)
+        return Robot(robot_name, tree, robot, position, time, parents=parents)
 
     def register_robot(self, robot):
         """


### PR DESCRIPTION
There is a bug in revolve.angle.manage.World in create_robot_manager() that creates revolve.angle.manage.Robot with wrong arguments.
