### PR TITLE
Yaml->proto converter fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ futures==3.0.2
 numpy==1.9.2
 protobuf==2.6.1
 -e git+https://github.com/ElteHupkes/pygazebo.git@revolve#egg=pygazebo
--e git+https://github.com:ElteHupkes/sdf-builder.git@master#egg=sdfbuilder
+-e git+https://github.com/ElteHupkes/sdf-builder.git@master#egg=sdfbuilder
 trollius==2.0
 wsgiref==0.1.2
 psutil==3.4.2

--- a/revolve/convert/decode.py
+++ b/revolve/convert/decode.py
@@ -212,8 +212,8 @@ class NeuralNetworkDecoder(object):
             neuron = neurons[neuron_id]
 
             self.neurons[neuron_id] = {
-                "layer": "hidden",
-                "type": "Simple",
+                "layer": neuron["layer"],
+                "type": neuron["type"],
                 "part_id": neuron["part_id"]
             }
 

--- a/revolve/convert/decode.py
+++ b/revolve/convert/decode.py
@@ -209,9 +209,12 @@ class NeuralNetworkDecoder(object):
             if neuron_id in self.neurons:
                 err("Duplicate neuron ID '%s'" % neuron_id)
 
+            neuron = neurons[neuron_id]
+
             self.neurons[neuron_id] = {
                 "layer": "hidden",
-                "type": "Simple"
+                "type": "Simple",
+                "part_id": neuron["part_id"]
             }
 
             self._process_neuron_params(neuron_id, neurons[neuron_id])

--- a/revolve/convert/decode.py
+++ b/revolve/convert/decode.py
@@ -210,12 +210,25 @@ class NeuralNetworkDecoder(object):
                 err("Duplicate neuron ID '%s'" % neuron_id)
 
             neuron = neurons[neuron_id]
+            layer = "hidden"
+            type = "Simple"
 
-            self.neurons[neuron_id] = {
-                "layer": neuron["layer"],
-                "type": neuron["type"],
-                "part_id": neuron["part_id"]
-            }
+            if "layer" in neuron:
+                layer = neuron["layer"]
+            if "type" in neuron:
+                type = neuron["type"]
+
+            if "part_id" in neuron:
+                self.neurons[neuron_id] = {
+                    "layer": layer,
+                    "type": type,
+                    "part_id": neuron["part_id"]
+                }
+            else:
+                self.neurons[neuron_id] = {
+                    "layer": layer,
+                    "type": type,
+                }
 
             self._process_neuron_params(neuron_id, neurons[neuron_id])
 

--- a/revolve/convert/decode.py
+++ b/revolve/convert/decode.py
@@ -210,24 +210,24 @@ class NeuralNetworkDecoder(object):
                 err("Duplicate neuron ID '%s'" % neuron_id)
 
             neuron = neurons[neuron_id]
-            layer = "hidden"
-            type = "Simple"
+            neuron_layer = "hidden"
+            neuron_type = "Simple"
 
             if "layer" in neuron:
-                layer = neuron["layer"]
+                neuron_layer = neuron["layer"]
             if "type" in neuron:
-                type = neuron["type"]
+                neuron_type = neuron["type"]
 
             if "part_id" in neuron:
                 self.neurons[neuron_id] = {
-                    "layer": layer,
-                    "type": type,
+                    "layer": neuron_layer,
+                    "type": neuron_type,
                     "part_id": neuron["part_id"]
                 }
             else:
                 self.neurons[neuron_id] = {
-                    "layer": layer,
-                    "type": type,
+                    "layer": neuron_layer,
+                    "type": neuron_type,
                 }
 
             self._process_neuron_params(neuron_id, neurons[neuron_id])


### PR DESCRIPTION
There is a problem with YAML->protobuf converter that makes it impossible to convert a YAML file if it contains a manually added neuron. The converter ignores 'part-id' of that neuron, as well as its 'layer' and 'type'.
I fixed it. Tests are passed successfully.
