### PR TITLE
Define default output directory in supervisor.py if not provided

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 2.8.12)
+
+project(revolve)
+
+add_subdirectory(cpp)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -124,7 +124,8 @@ endforeach()
 set_source_files_properties(${PROTO_SRCS} ${PROTO_HDRS} PROPERTIES GENERATED TRUE)
 
 # Generate spec library with the messages
-add_library(revolve-spec STATIC ${PROTO_SRCS} )
+add_library(revolve-spec STATIC ${PROTO_SRCS})
+set_target_properties(revolve-spec PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(revolve-spec ${PROTOBUF_LIBRARIES})
 
 #### Other sources #######

--- a/revolve/angle/manage/world.py
+++ b/revolve/angle/manage/world.py
@@ -361,6 +361,8 @@ class WorldManager(manage.WorldManager):
         :type tree: Tree
         :param pose: Insertion pose
         :type pose: Pose
+        :param name: Robot name
+        :type name: str
         :param initial_battery: Initial battery level
         :param parents:
         :return: A future that resolves with the created `Robot` object.

--- a/revolve/angle/manage/world.py
+++ b/revolve/angle/manage/world.py
@@ -344,7 +344,7 @@ class WorldManager(manage.WorldManager):
         raise Return(coll, bbox, robot)
 
     @trollius.coroutine
-    def insert_robot(self, tree, pose, initial_battery=0.0, parents=None):
+    def insert_robot(self, tree, pose, name=None, initial_battery=0.0, parents=None):
         """
         Inserts a robot into the world. This consists of two steps:
 
@@ -366,7 +366,8 @@ class WorldManager(manage.WorldManager):
         :return: A future that resolves with the created `Robot` object.
         """
         robot_id = self.get_robot_id()
-        robot_name = "gen__"+str(robot_id)
+        robot_name = "gen__"+str(robot_id) \
+            if name is None else str(name)
 
         robot = tree.to_robot(robot_id)
         sdf = self.get_simulation_sdf(robot, robot_name, initial_battery)

--- a/revolve/build/sdf/builder.py
+++ b/revolve/build/sdf/builder.py
@@ -295,7 +295,7 @@ class RobotBuilder(object):
         self.brain_builder = brain_builder
 
     def get_sdf_model(self, robot, controller_plugin=None, update_rate=5, name="sdf_robot",
-                      analyzer_mode=False, battery=None):
+                      analyzer_mode=False, battery=None, brain_conf=None):
         """
         :param robot: Protobuf robot
         :type robot: Robot
@@ -310,6 +310,8 @@ class RobotBuilder(object):
         :param battery: A Battery element to be added to the plugin if
                         applicable.
         :type battery: Element
+        :param brain_conf: Brain configuration data
+        :type brain_conf: dict
         :return: The sdf-builder Model
         :rtype: Model
         """
@@ -329,7 +331,7 @@ class RobotBuilder(object):
         plugin.add_element(config)
 
         # Add brain config element
-        brain_config = Element(tag_name='rv:brain')
+        brain_config = Element(tag_name='rv:brain', attributes=brain_conf)
         config.add_element(brain_config)
 
         self.brain_builder.build(robot, model, brain_config, analyzer_mode)

--- a/revolve/util/supervisor/supervisor.py
+++ b/revolve/util/supervisor/supervisor.py
@@ -44,7 +44,7 @@ class Supervisor(object):
     and it should restore the world state from there.
     """
 
-    def __init__(self, manager_cmd, world_file, output_directory, manager_args=None, gazebo_cmd="gzserver",
+    def __init__(self, manager_cmd, world_file, output_directory=None, manager_args=None, gazebo_cmd="gzserver",
                  analyzer_cmd=None, gazebo_args=None, restore_arg="--restore-directory",
                  snapshot_world_file="snapshot.world", restore_directory=None):
         """
@@ -65,7 +65,8 @@ class Supervisor(object):
         """
         self.restore_directory = datetime.now().strftime('%Y%m%d%H%M%S') \
             if restore_directory is None else restore_directory
-        self.output_directory = os.path.abspath(output_directory)
+        self.output_directory = 'output' \
+            if output_directory is None else os.path.abspath(output_directory)
         self.snapshot_directory = os.path.join(self.output_directory, self.restore_directory)
         self.snapshot_world_file = snapshot_world_file
         self.restore_arg = restore_arg
@@ -89,10 +90,10 @@ class Supervisor(object):
         (Re)launches the experiment.
         :return:
         """
-        if not os.path.exists(self.snapshot_directory):
-            os.mkdir(self.snapshot_directory)
         if not os.path.exists(self.output_directory):
             os.mkdir(self.output_directory)
+        if not os.path.exists(self.snapshot_directory):
+            os.mkdir(self.snapshot_directory)
 
         success = False
         while not success:


### PR DESCRIPTION
I am lazy to define the output dir and all this small things, so I always make this safety nets, just in case I forgot to define something.
